### PR TITLE
Update train_classification_net.py

### DIFF
--- a/train_classification_net.py
+++ b/train_classification_net.py
@@ -102,8 +102,9 @@ def testNet(i, test_dataset_dir, solver, numTestSamples, auroc = False):
 
 # load mean
 meanHdf = h5py.File(os.path.join(TRAIN_DATASET_DIR, DATASET_MEAN_FILENAME), 'r')
-mean = np.zeros(meanHdf['mean'][...].shape, meanHdf['mean'][...].dtype)
-mean[...] = meanHdf['mean'][...]
+#mean = np.zeros(meanHdf['mean'][...].shape, meanHdf['mean'][...].dtype)
+#mean[...] = meanHdf['mean'][...]
+mean = np.zeros(meanHdf)
 meanHdf.close()
 
 moving_window = NUM_TRAINING_ITERATIONS / 50


### PR DESCRIPTION
Environment: Windows 10 (Python 3.5.2)
Replace lines 105-106 with:
mean = np.zeros(meanHdf)

Was receiving error:
'File' object has no attribute 'encode' in base.py (line 137) from h5py/_hl/base.py